### PR TITLE
Mark shard latency as nullable

### DIFF
--- a/dist/sharding/Admiral.d.ts
+++ b/dist/sharding/Admiral.d.ts
@@ -200,7 +200,7 @@ export interface Options {
     softKillNotificationPeriod?: number;
 }
 export interface ShardStats {
-    latency: number;
+    latency: number | null;
     id: number;
     ready: boolean;
     status: Eris.Shard["status"];

--- a/src/sharding/Admiral.ts
+++ b/src/sharding/Admiral.ts
@@ -245,7 +245,7 @@ export interface Options {
 }
 
 export interface ShardStats {
-	latency: number;
+	latency: number | null;
 	id: number;
 	ready: boolean;
 	status: Eris.Shard["status"];


### PR DESCRIPTION
Eris emits latency as `Infinity` when there isn't enough data yet (~first 1 minute). eris-fleet serializes this with `JSON.stringify` during IPC, which serializes it to `null`. 